### PR TITLE
Pin dotnet-runtime to version 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get install -y wget gnupg && \
     dpkg -i packages-microsoft-prod.deb && \
     rm -f packages-microsoft-prod.deb && \
     apt-get update && \
-    apt-get -y install apt-transport-https dotnet-runtime-3.1 dotnet-runtime-5.0 && \
+    apt-get -y install apt-transport-https dotnet-runtime-3.1 dotnet-runtime-5.0=5.0.0-1 && \
     # install altV module
     wget --no-cache -q -O /opt/altv/modules/libcsharp-module.so https://cdn.altv.mp/coreclr-module/${BRANCH}/x64_linux/modules/libcsharp-module.so && \
     mkdir -p /usr/share/dotnet/host/fxr/ && \


### PR DESCRIPTION
This will fix the following error in the release channel:

altv_1        | Unhandled exception. System.IO.FileLoadException: Could not load file or assembly 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)
altv_1        | File name: 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'