### PR TITLE
fix: logfile not being used because of equal sign

### DIFF
--- a/.docker/scripts/entrypoint.sh
+++ b/.docker/scripts/entrypoint.sh
@@ -46,7 +46,7 @@ if [ ! -z "$ALTV_SERVER_WEBSITE" ]; then
 fi
 
 if [ ! -z "$ALTV_SERVER_LOG_PATH" ]; then
-    ALTV_SERVER_LOG_PATH="--logfile=$ALTV_SERVER_LOG_PATH"
+    ALTV_SERVER_LOG_PATH="--logfile $ALTV_SERVER_LOG_PATH"
 fi
 
 if [ "$ALTV_SERVER_NO_LOGFILE" = "true" ]; then


### PR DESCRIPTION
I first tried to run the container with environment variable `ALTV_SERVER_LOG_PATH=log/server.log`. Looking into the running container, it didn't create the file. Then replaced the equal sign with a space in the entrypoint inside the container (`sed -i 's/--logfile=/--logfile /g' entrypoint.sh`) and then executed the entrypoint, it successfully created a log-file.

Seems like Alt:V server interprets the `--logfile` argument only without an equal sign unlike most other CLI programs.

